### PR TITLE
Enhanced function documentation.

### DIFF
--- a/R/wait_for_postgres.R
+++ b/R/wait_for_postgres.R
@@ -1,9 +1,10 @@
 library(RPostgres)
 library(DBI)
 
-#' Connect to Postgres, waiting if it is not ready
+#' Connect to a PostgreSQL database, waiting if it is not ready
 #'
-#' Assumptions: host = "localhost" and port = "5432".
+#' This function is used during development to connect to an instance of PostgreSQL that is running on the developer's local machine, such as in a Docker container.
+#'    Assumptions: host = "localhost" and port = "5432".
 #' @param user Username for connecting to the database
 #' @param password Password that corresponds to the username
 #' @param dbname the name of the database within the database server

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -117,7 +117,7 @@
         <td>
           <p><code><a href="wait_for_postgres.html">wait_for_postgres()</a></code> </p>
         </td>
-        <td><p>Connect to Postgres, waiting if it is not ready</p></td>
+        <td><p>Connect to a PostgreSQL database, waiting if it is not ready</p></td>
       </tr>
     </tbody>
     </table>

--- a/docs/reference/wait_for_postgres.html
+++ b/docs/reference/wait_for_postgres.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Connect to Postgres, waiting if it is not ready — wait_for_postgres • sqlpetr</title>
+<title>Connect to a PostgreSQL database, waiting if it is not ready — wait_for_postgres • sqlpetr</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -30,9 +30,10 @@
 
 
 
-<meta property="og:title" content="Connect to Postgres, waiting if it is not ready — wait_for_postgres" />
+<meta property="og:title" content="Connect to a PostgreSQL database, waiting if it is not ready — wait_for_postgres" />
 
-<meta property="og:description" content="Assumptions: host = &quot;localhost&quot; and port = &quot;5432&quot;." />
+<meta property="og:description" content="This function is used during development to connect to an instance of PostgreSQL that is running on the developer's local machine, such as in a Docker container.
+   Assumptions: host = &quot;localhost&quot; and port = &quot;5432&quot;." />
 <meta name="twitter:card" content="summary" />
 
 
@@ -97,14 +98,15 @@
 <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>Connect to Postgres, waiting if it is not ready</h1>
+    <h1>Connect to a PostgreSQL database, waiting if it is not ready</h1>
     <small class="dont-index">Source: <a href='https://github.com/smithjd/sqlpetr/blob/master/R/wait_for_postgres.R'><code>R/wait_for_postgres.R</code></a></small>
     <div class="hidden name"><code>wait_for_postgres.Rd</code></div>
     </div>
 
     <div class="ref-description">
     
-    <p>Assumptions: host = "localhost" and port = "5432".</p>
+    <p>This function is used during development to connect to an instance of PostgreSQL that is running on the developer's local machine, such as in a Docker container.
+   Assumptions: host = "localhost" and port = "5432".</p>
     
     </div>
 

--- a/man/wait_for_postgres.Rd
+++ b/man/wait_for_postgres.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/wait_for_postgres.R
 \name{wait_for_postgres}
 \alias{wait_for_postgres}
-\title{Connect to Postgres, waiting if it is not ready}
+\title{Connect to a PostgreSQL database, waiting if it is not ready}
 \usage{
 wait_for_postgres(user, password, dbname, seconds_to_test = 10)
 }
@@ -19,5 +19,6 @@ wait_for_postgres(user, password, dbname, seconds_to_test = 10)
 When successful: a connection object, which is an S4 object that inherits from DBIConnection used to communicate with the database engine; Otherwise, an error string.
 }
 \description{
-Assumptions: host = "localhost" and port = "5432".
+This function is used during development to connect to an instance of PostgreSQL that is running on the developer's local machine, such as in a Docker container.
+   Assumptions: host = "localhost" and port = "5432".
 }

--- a/tests/test_pkg.sh
+++ b/tests/test_pkg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-echo "1. Building package documentation ..."
-R -e "library(pkgdown); pkgdown::build_site()"
-echo "2. Building function documentation ..."
+echo "1. Building function documentation ..."
 R -e "library(devtools); devtools::load_all(); devtools::document()"
+echo "2. Building package documentation ..."
+R -e "library(pkgdown); pkgdown::build_site()"
 echo "3. Checking package, including unit tests ..."
 R -e "library(devtools); devtools::load_all(); devtools::check()"


### PR DESCRIPTION
* After looking at rendered documentation at https://smithjd.github.io/sqlpetr/reference/wait_for_postgres.html , I edited the documentation of `wait_for_postgres` slightly.
* Fixed the `test_pkg.sh` script, because `devtools::document()` needs to run before `pkgdown::build_site()`, in order for changes to function documentation to show up on the generated web site.